### PR TITLE
chore: add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+version: 2
+updates:
+  # Enable version updates for Python dependencies
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "movici-team"
+    assignees:
+      - "movici-team"
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      development:
+        patterns:
+          - "pytest*"
+          - "black*"
+          - "flake8*"
+          - "isort*"
+          - "mypy*"
+          - "pre-commit*"
+          - "coverage*"
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 3
+    reviewers:
+      - "movici-team"
+    assignees:
+      - "movici-team"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"


### PR DESCRIPTION
## Summary
  - Adds Dependabot configuration to automate dependency updates
  - Standardizes configuration across movici-* repositories for 
  consistency
  - Improves security by keeping dependencies up-to-date
  - Reduces manual maintenance burden

  ## Changes
  - Configure weekly Python dependency updates via pip ecosystem
  - Configure weekly GitHub Actions updates
  - Group development and production dependencies separately
  - Set up automatic PR assignment and review requests
  - Configure commit message prefixes for consistency
  - Limit open PRs to manage update volume
  - Aligns with standardized Dependabot configurations used in other 
  movici-* repositories

  ## Benefits
  - Automated security updates for vulnerable dependencies
  - Regular dependency updates to stay current
  - Grouped updates reduce PR noise
  - Consistent commit message format
  - Unified dependency management strategy across Movici ecosystem

  ## Test Plan
  - [x] YAML syntax validated
  - [x] Configuration matches other movici-* repository standards
  - [ ] Dependabot will activate after merge to main