### PR TITLE
chore: update Dependabot config and add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @nginfra/movici-team

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,6 @@ updates:
       day: "monday"
       time: "09:00"
     open-pull-requests-limit: 5
-    assignees:
-      - "nginfra/movici-team"
     labels:
       - "dependencies"
       - "python"
@@ -26,6 +24,15 @@ updates:
           - "mypy*"
           - "pre-commit*"
           - "coverage*"
+      production:
+        exclude-patterns:
+          - "pytest*"
+          - "black*"
+          - "flake8*"
+          - "isort*"
+          - "mypy*"
+          - "pre-commit*"
+          - "coverage*"
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
@@ -35,8 +42,6 @@ updates:
       day: "monday"
       time: "09:00"
     open-pull-requests-limit: 3
-    assignees:
-      - "nginfra/movici-team"
     labels:
       - "dependencies"
       - "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,15 +8,13 @@ updates:
       day: "monday"
       time: "09:00"
     open-pull-requests-limit: 5
-    reviewers:
-      - "movici-team"
     assignees:
-      - "movici-team"
+      - "nginfra/movici-team"
     labels:
       - "dependencies"
       - "python"
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "chore"
       include: "scope"
     groups:
       development:
@@ -37,13 +35,11 @@ updates:
       day: "monday"
       time: "09:00"
     open-pull-requests-limit: 3
-    reviewers:
-      - "movici-team"
     assignees:
-      - "movici-team"
+      - "nginfra/movici-team"
     labels:
       - "dependencies"
       - "github-actions"
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "chore"
       include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:00"
+    cooldown:
+      default-days: 14
     open-pull-requests-limit: 5
     labels:
       - "dependencies"


### PR DESCRIPTION
## Summary
- Updated Dependabot configuration to remove assignees field
- Added production exclude patterns for development dependencies
- Added CODEOWNERS file to define code ownership

## Changes
- Removed `assignees` field from Dependabot configuration
- Added `production` exclude patterns to prevent dev dependencies from being included in production dependency updates
- Created `.github/CODEOWNERS` file with team ownership